### PR TITLE
Normalize locale when reading/writing to files

### DIFF
--- a/src/Console/Commands/SyncTranslations.php
+++ b/src/Console/Commands/SyncTranslations.php
@@ -242,7 +242,8 @@ class SyncTranslations extends Command
             File::makeDirectory($directory, recursive: true);
         }
 
-        $filePath = sprintf('%s/%s.json', $directory, $locale);
+        $normalizedLocale = LaravelTranslationsSync::normalizeLocale($locale);
+        $filePath = sprintf('%s/%s.json', $directory, $normalizedLocale);
         $encoded = json_encode($lines, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         if (File::exists($filePath)) {
@@ -257,7 +258,8 @@ class SyncTranslations extends Command
      */
     protected function writePhp(string $locale, string $filename, array $lines): void
     {
-        $directory = sprintf('%s/%s', lang_path(), $locale);
+        $normalizedLocale = LaravelTranslationsSync::normalizeLocale($locale);
+        $directory = sprintf('%s/%s', lang_path(), $normalizedLocale);
 
         // The translation directory doesn't exist, so create it.
         if (!File::exists($directory)) {

--- a/src/LaravelTranslationsSync.php
+++ b/src/LaravelTranslationsSync.php
@@ -35,6 +35,22 @@ class LaravelTranslationsSync
     }
 
     /**
+     * Normalize the locale to a standard format.
+     */
+    public function normalizeLocale(string $locale): string
+    {
+        if (str_contains($locale, '_')) {
+            $parts = explode('_', $locale);
+
+            if (count($parts) >= 2) {
+                return sprintf('%s_%s', strtolower($parts[0]), strtoupper($parts[1]));
+            }
+        }
+
+        return strtolower($locale);
+    }
+
+    /**
      * Return all the translations.
      */
     public function getAllTranslations(): array
@@ -51,18 +67,19 @@ class LaravelTranslationsSync
      */
     public function getTranslationsForLocale(string $locale): array
     {
+        $normalizedLocale = $this->normalizeLocale($locale);
         $strings = [];
 
         // Load all translation files from the locale's directory.
-        if (File::exists(lang_path($locale))) {
-            foreach (File::files(lang_path($locale)) as $file) {
+        if (File::exists(lang_path($normalizedLocale))) {
+            foreach (File::files(lang_path($normalizedLocale)) as $file) {
                 $name = basename($file);
                 $strings[$name] = require $file;
                 ksort($strings[$name], SORT_STRING | SORT_FLAG_CASE);
             }
         }
 
-        $jsonPath = lang_path("$locale.json");
+        $jsonPath = lang_path("$normalizedLocale.json");
         if (File::exists($jsonPath)) {
             $json = File::get($jsonPath);
             $strings['json'] = json_decode($json, true, flags: JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Fixes

- Normalizes the locale when reading or writing to files. Example results: `en`, `en_US`.